### PR TITLE
Replace hardcoded number error alert message my invocation to messages obj 

### DIFF
--- a/packages/blocklib-number-block/src/renderer/display.js
+++ b/packages/blocklib-number-block/src/renderer/display.js
@@ -64,7 +64,7 @@ const NumberOutput = (props) => {
 
 		const value = e.target.value;
 		if (isNaN(value)) {
-			blockWithError('Numbers only!');
+			blockWithError(messages['label.errorAlert.number']);
 			return;
 		}
 		if (value !== 0 && !value) {


### PR DESCRIPTION
This is the approach followed in the other blocks, otherwise users cannot customise the number error alert message. 