### PR TITLE
Fix override slug if slug is set to empty

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -141,15 +141,15 @@ class Core {
 			'menu_position'      => 30,
 			'show_in_rest'       => true,
 		);
+
 		if ( Settings::get( 'override_quillforms_slug' ) === true ) {
-			if (! empty( Settings::get( 'quillforms_slug' ) ) ) {
+			if ( null !== Settings::get( 'quillforms_slug' ) ) {
 				$args['rewrite']['slug'] = Settings::get( 'quillforms_slug' );
 			}
-			
-		} 
+		}
 
 		$args['rewrite']['slug'] = apply_filters('quillforms_rewrite_slug', $args['rewrite']['slug']);
-		
+
 		register_post_type( 'quill_forms', $args );
 	}
 
@@ -236,7 +236,7 @@ class Core {
 		$messages         = get_post_meta( $form_id, 'messages', true );
 		if(empty($messages)) {
 			$messages = array();
-		}	
+		}
 		$default_messages = Client_Messages::instance()->get_messages();
 		foreach ( $default_messages as $key => $message ) {
 			if ( ! $message['default'] ) {


### PR DESCRIPTION
Fixes the bug where this option doesn't work if set to empty:

![SCR-20240517-lqwm-2](https://github.com/quillforms/quillforms/assets/1534150/e6d87561-933c-4d0d-97c1-7445af5c9510)

![SCR-20240517-lrai-2](https://github.com/quillforms/quillforms/assets/1534150/fc72ac09-35f0-4c8c-a8bc-8857251f7a75)

Tested the PR and it's working when using null check instead of ! empty.